### PR TITLE
replace custom CPU feature detection

### DIFF
--- a/poly1305_amd64.go
+++ b/poly1305_amd64.go
@@ -7,13 +7,11 @@
 package poly1305
 
 import (
+	"golang.org/x/sys/cpu"
 	"io"
 )
 
-var useAVX2 = supportsAVX2()
-
-//go:noescape
-func supportsAVX2() bool
+var useAVX2 = cpu.X86.HasAVX2
 
 //go:noescape
 func initialize(state *[7]uint64, key *[32]byte)


### PR DESCRIPTION
I have this problem using go1.11beta1 in Fedora Rawhide:

```
Testing: github.com/aead/poly1305
Testing: "/builddir/build/BUILD/poly1305-969857f48f7ae439b6d2449ed1dcd9aaabc49c67/_build/src/github.com/aead/poly1305"
+ GOPATH=/builddir/build/BUILD/poly1305-969857f48f7ae439b6d2449ed1dcd9aaabc49c67/_build:/usr/share/gocode
+ go test -buildmode pie -compiler gc -ldflags '-extldflags '\''-Wl,-z,relro   -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '\'''
# github.com/aead/poly1305.test
github.com/aead/poly1305.supportsAVX2: relocation target runtime.support_avx2 not defined
```

PR solves this issue using your own code from https://github.com/minio/highwayhash/pull/7

I've tested it in Fedora. (https://koji.fedoraproject.org/koji/taskinfo?taskID=28346217)